### PR TITLE
Introduce WithNewTraceID helper

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -19,6 +19,11 @@ func WithTraceID(ctx context.Context) context.Context {
 		return ctx
 	}
 
+	return WithNewTraceID(ctx)
+}
+
+// WithNewTraceID returns a new context with a random trace ID.
+func WithNewTraceID(ctx context.Context) context.Context {
 	v := zap.String("_trace_id", newTraceID())
 	return context.WithValue(ctx, ctxTraceID, &v)
 }

--- a/trace_test.go
+++ b/trace_test.go
@@ -20,6 +20,23 @@ func TestWithTraceID(t *testing.T) {
 	}
 }
 
+func TestWithNewTraceID(t *testing.T) {
+	ctx := WithTraceID(context.Background())
+	id := TraceID(ctx)
+	if id == "" {
+		t.Fatal("missing id")
+	}
+
+	newCtx := WithNewTraceID(ctx)
+	newID := TraceID(newCtx)
+	if id == newID {
+		t.Fatal("expected new trace ID")
+	}
+	if newCtx == ctx {
+		t.Fatal("expected new context")
+	}
+}
+
 func TestCopyTraceID(t *testing.T) {
 	from := WithTraceID(context.Background())
 	ctx := context.Background()


### PR DESCRIPTION
Helper returns new context with new generated trace ID. 

See https://github.com/scylladb/mermaid/issues/857 for details.