### PR TITLE
Introduce WithFields helper

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,10 +2,72 @@
 
 package log
 
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
 // ctxt is a context key type.
 type ctxt byte
 
 // ctxt enumeration.
 const (
 	ctxTraceID ctxt = iota
+	ctxFields
 )
+
+// WithFields assigns additional fields to the logging context.
+// Existing fields are overridden and new fields are added.
+func WithFields(ctx context.Context, keyvals ...interface{}) context.Context {
+	if len(keyvals)%2 != 0 || len(keyvals) == 0 {
+		return ctx
+	}
+
+	fields := make([]zapcore.Field, 0, len(keyvals)/2)
+	for i := 0; i < len(keyvals); i += 2 {
+		// Consume this value and the next, treating them as a key-value pair.
+		key, val := keyvals[i], keyvals[i+1]
+		if keyStr, ok := key.(string); !ok {
+			break
+		} else {
+			fields = append(fields, zap.Any(keyStr, val))
+		}
+	}
+
+	var value []zapcore.Field
+	v := ctx.Value(ctxFields)
+	if v == nil {
+		value = make([]zapcore.Field, 0, len(fields))
+	} else {
+		value = v.([]zapcore.Field)
+	}
+	for i := range fields {
+		found := false
+		for j := range value {
+			if value[j].Key == fields[i].Key {
+				value[j] = fields[i]
+				found = true
+				break
+			}
+		}
+		if !found {
+			value = append(value, fields[i])
+		}
+	}
+	return context.WithValue(ctx, ctxFields, value)
+}
+
+// Fields returns key-value pairs assigned to the context sorted by the key.
+func Fields(ctx context.Context) []zapcore.Field {
+	if ctx == nil {
+		return nil
+	}
+	v, ok := ctx.Value(ctxFields).([]zapcore.Field)
+	if !ok {
+		return nil
+	}
+
+	return v
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,55 @@
+package log
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestWithFields(t *testing.T) {
+	ctx := WithFields(context.Background())
+	flds := Fields(ctx)
+
+	t.Run("empty log context", func(t *testing.T) {
+		if len(flds) != 0 {
+			t.Fatal("initial fields should be empty", flds)
+		}
+	})
+
+	t.Run("invalid number of keyvals", func(t *testing.T) {
+		ctx = WithFields(ctx, "key1", 1, "key2")
+		flds = Fields(ctx)
+		if len(flds) != 0 {
+			t.Fatalf("expected 0 fields on error got %d", len(flds))
+		}
+	})
+
+	t.Run("valid log context", func(t *testing.T) {
+		ctx = WithFields(ctx, "key1", 1, "key2", "val2")
+		flds = Fields(ctx)
+		if len(flds) != 2 {
+			t.Fatalf("expected 2 fields got %d", len(flds))
+		}
+		if flds[0].Key != "key1" || flds[0].Integer != 1 {
+			t.Errorf(`expected "key1"=1, got %q=%+v`, flds[0].Key, flds[0].Integer)
+		}
+	})
+}
+
+func TestWithFieldsInfo(t *testing.T) {
+	ctx := WithFields(context.Background(), "key1", 1)
+	core, o := observer.New(zap.InfoLevel)
+	l := NewLogger(zap.New(core))
+	l.Info(ctx, "testing", "key2", "val2")
+
+	flds := o.FilterMessage("testing").All()[0].Context
+
+	if len(flds) != 2 {
+		t.Fatalf("expected 2 fields got %d", len(flds))
+	}
+	if flds[1].Key != "key1" || flds[1].Integer != 1 {
+		t.Errorf(`expected "key1"=1, got %q=%+v`, flds[0].Key, flds[0].Integer)
+	}
+}

--- a/logger.go
+++ b/logger.go
@@ -90,6 +90,7 @@ func (l Logger) zapify(ctx context.Context, keyvals []interface{}) []zapcore.Fie
 
 	var (
 		extraFields int
+		extra       []zapcore.Field
 		trace       *zapcore.Field
 		ok          bool
 	)
@@ -99,6 +100,8 @@ func (l Logger) zapify(ctx context.Context, keyvals []interface{}) []zapcore.Fie
 		if ok {
 			extraFields++
 		}
+		extra = Fields(ctx)
+		extraFields += len(extra)
 	}
 
 	if len(keyvals)+extraFields == 0 {
@@ -115,6 +118,10 @@ func (l Logger) zapify(ctx context.Context, keyvals []interface{}) []zapcore.Fie
 		} else {
 			fields = append(fields, zap.Any(keyStr, val))
 		}
+	}
+
+	if len(extra) > 0 {
+		fields = append(fields, extra...)
 	}
 
 	if trace != nil {


### PR DESCRIPTION
Use context to pass additional fields to the log entry.
Log entries called with that context will output these additional fields.

See https://github.com/scylladb/mermaid/issues/858 for details.