### PR TITLE
config: using zap.LevelEnabler instead of Level

### DIFF
--- a/config.go
+++ b/config.go
@@ -56,8 +56,8 @@ func (m *Mode) UnmarshalText(text []byte) error {
 
 // Config specifies log mode and level.
 type Config struct {
-	Mode  Mode          `yaml:"mode"`
-	Level zapcore.Level `yaml:"level"`
+	Mode  Mode                 `yaml:"mode"`
+	Level zapcore.LevelEnabler `yaml:"level"`
 }
 
 // NewProduction builds a production Logger based on the configuration.


### PR DESCRIPTION
The reason for this is to allow the caller to supply a zapcore.Atomic
that enables runtime switching of levels.